### PR TITLE
Split CacheDecorator into generic base + RepositoryCacheDecorator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 .idea
+.phpunit.cache/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-`trm42/cache-decorator` is a Laravel package (currently targeting Laravel 12 and 13 on PHP 8.2+) that provides a magical caching decorator for repository classes. Consumers subclass `CacheDecorator` and declare a `repository()` method returning the wrapped repository's class name; method calls on the decorator are auto-cached via Laravel's `Cache` facade.
+`trm42/cache-decorator` is a Laravel package (currently targeting Laravel 12 and 13 on PHP 8.2+) that provides a magical caching decorator for any wrapped object. The generic base class `CacheDecorator` decorates an arbitrary object (services, API clients, query objects, etc.); the `RepositoryCacheDecorator` subclass specializes it for the original repository-flavored API. Method calls on the decorator are auto-cached via Laravel's `Cache` facade.
 
 ## Commands
 
@@ -17,19 +17,22 @@ PHPUnit ^11 is used (PHPUnit 12 also allowed); test bootstrap is `vendor/autoloa
 
 ## Architecture
 
-The package is intentionally small — three production files plus tests.
+The package is intentionally small — four production files plus tests.
 
-- **`src/CacheDecorator.php`** — abstract base. The core mechanism is `__call($method, $arguments)`: if the method is cacheable (not in `$excludes`), it builds a key via `generateCacheKey()`, checks `Cache::get` (with `tags()` if `$tags` is set), and on miss forwards to the underlying repository via `callMethod()` (which uses `method_exists` + `call_user_func_array` and throws `BadMethodCallException` if missing). Methods listed in `$tag_cleaners` trigger `Cache::tags(...)->flush()` after the call.
-- **`initExcludes()`** auto-adds the decorator's own protected/public method names to `$excludes` so they aren't intercepted by `__call`. If you add new helper methods on `CacheDecorator`, add them to the `$defaults` list in `initExcludes()` or `__call` will try to forward them to the repository.
+- **`src/CacheDecorator.php`** — abstract base. The core mechanism is `__call($method, $arguments)`: if the method is cacheable (not in `$excludes`), it builds a key via `generateCacheKey()`, checks `Cache::get` (with `tags()` if `$tags` is set), and on miss forwards to `$this->decorated` via `callMethod()` (which uses `method_exists` + `call_user_func_array` and throws `BadMethodCallException` if missing). Methods listed in `$tag_cleaners` trigger `Cache::tags(...)->flush()` after the call. Subclasses either pass an instance to the constructor or override `decoratedClass(): ?string` to return a FQCN for default instantiation; if neither is provided, `initDecorated()` throws `LogicException`.
+- **`src/RepositoryCacheDecorator.php`** — repository-flavored subclass. Adds an abstract `repository(): string` method, mirrors `$this->decorated` into `$this->repository` so user overrides can keep using the familiar idiom, and overrides `$config_key` to `'repository_cache'`. `initExcludes()` is extended to also exclude `'repository'` and `'initRepository'`.
+- **`initExcludes()`** auto-adds the decorator's own protected/public method names to `$excludes` so they aren't intercepted by `__call`. If you add new helper methods on `CacheDecorator`, add them to the `$defaults` list in `initExcludes()` or `__call` will try to forward them to the decorated object. The same caveat applies to `RepositoryCacheDecorator`'s override.
 - **Cache key format** is `{prefix_key}.{method}.{argKey}={argVal}...` built by `generateCacheKey()` using `Illuminate\Support\Arr::dot($arguments)`. Note: arguments that are objects are not supported (a known TODO in the class header).
 - **TTL semantic**: `$ttl` is in **seconds** (Laravel 5.8+ `Cache::put` API) and may also be `DateInterval` / `DateTimeInterface`. `$ttl === false` is a sentinel that bypasses both reads and writes to the cache.
-- **Config** is read in `getConfig()` from `repository_cache.*` (`ttl`, `enabled`, `use_tags`) plus `app.debug` for the `$debug` flag controlling `Log::debug` output.
-- **`src/ServiceProvider.php`** — only publishes the default config (`config/repository_cache.php`) to the host app's `config/` directory under the `repository-cache-config` publish tag; `register()` is empty. The provider is auto-discovered via `extra.laravel.providers` in `composer.json`.
+- **Config** is read in `getConfig()` from `{$this->config_key}.*` (`ttl`, `enabled`, `use_tags`) plus `app.debug` for the `$debug` flag controlling `Log::debug` output. The base default is `'cache_decorator'`; `RepositoryCacheDecorator` overrides it to `'repository_cache'`.
+- **`src/ServiceProvider.php`** — publishes both config files: `config/cache_decorator.php` under the `cache-decorator-config` tag and `config/repository_cache.php` under the `repository-cache-config` tag; `register()` is empty. The provider is auto-discovered via `extra.laravel.providers` in `composer.json`.
 
-The class uses Laravel facades (`Cache`, `Config`, `Log` from `Illuminate\Support\Facades`), so this package is Laravel-coupled — the TODO in the header notes a future goal to decouple. When testing, the underlying repository class is instantiated via `new $class` inside `initRepository()` unless an instance is injected through the constructor.
+The classes use Laravel facades (`Cache`, `Config`, `Log` from `Illuminate\Support\Facades`), so this package is Laravel-coupled — the TODO in the header notes a future goal to decouple. When testing the no-arg construction path, the decorated class is instantiated via `new $class` inside `initDecorated()` unless an instance is injected through the constructor.
 
 ## Conventions
 
-- Subclasses set `$ttl`, `$prefix_key`, `$excludes`, `$tag_cleaners`, `$tags` as protected properties and implement `repository()` returning a FQCN string.
+- Generic subclasses extend `CacheDecorator`, set `$ttl`, `$prefix_key`, `$excludes`, `$tag_cleaners`, `$tags` as protected properties, and either inject the decorated instance via the constructor or override `decoratedClass()` returning a FQCN string.
+- Repository subclasses extend `RepositoryCacheDecorator` and implement `repository(): string` — same property knobs apply.
+- Inside custom method overrides on a generic decorator, reference the inner object as `$this->decorated`; on a `RepositoryCacheDecorator` you can use either `$this->decorated` or the familiar `$this->repository`.
 - To customize caching for a single method, override it in the subclass and use the protected helpers `generateCacheKey()`, `getCache()`, `putCache()` (see README example).
-- TTL values throughout (subclass `$ttl`, `repository_cache.ttl` config, calls to `setTtl()`) are in seconds — this changed from "minutes" when upgrading from the Laravel 5.x line.
+- TTL values throughout (subclass `$ttl`, `cache_decorator.ttl` / `repository_cache.ttl` config, calls to `setTtl()`) are in seconds — this changed from "minutes" when upgrading from the Laravel 5.x line.

--- a/README.md
+++ b/README.md
@@ -1,106 +1,152 @@
-# (Magical) Cache Decorator for Laravel Repositories
+# (Magical) Cache Decorator for Laravel
 
-Repositories are really, really nice thing that solves real-world issues and follows the idea of DRY (Don't Repeat Yourself), but making similar classes for repository caching and repeating yourself over and over again for code like this: 
+A transparent caching decorator for any Laravel-side class — services, API clients, query objects, repositories, you name it. Sub-class `CacheDecorator`, point it at the object you want to cache, and every public method call is automatically cached on first run and served from the cache on subsequent calls.
+
+Stop writing boilerplate like this for every class whose results you want to cache:
 
 ```PHP
 namespace something\nice;
 
-class CachedUserRepository {
-	
-	protected $repository;
-	protected $cache;
+class CachedReportingService {
 
-	public function __construct(UserRepository $users, Cache $cache) {
-		$this->repository = $users;
-		$this->cache = $cache;
-	}
+    protected $service;
+    protected $cache;
 
-	function all()
-	{
-		if (!$this->cache->has('all')) {
-			$results = $this->repository->all();
-			$this->cache->save('all', $results);
-		} else {
-			$results = $this->cache->get('all');
-		}
+    public function __construct(ReportingService $service, Cache $cache) {
+        $this->service = $service;
+        $this->cache = $cache;
+    }
 
-		return $results;
+    public function dailyTotals($date)
+    {
+        $key = 'daily-totals-' . $date;
+        if (!$this->cache->has($key)) {
+            $results = $this->service->dailyTotals($date);
+            $this->cache->save($key, $results);
+        } else {
+            $results = $this->cache->get($key);
+        }
 
-	}
+        return $results;
+    }
 
-	function findByX($x)
-	{
-		$key = 'find-' . $x;
-		if (!$this->cache->has($key)) {
-			$results = $this->repository->findByX($x);
-			$this->cache->save($key, $results);
-		} else {
-			$results = $this->cache->get($key);
-		}
-
-		return $results;
-	}
+    // ... and the same for every other method
 }
 ```
 
-And repeat this for every repository class in your project. Lots of dull repetition. Also, it doesn't help to make the caching code as part of your repository base class as it violates the single responsibility principle.
-
-Cue (Magical) Cache Decorator which handles these things automatically for you with just few lines of class declaration:
+With `CacheDecorator` the above shrinks to:
 
 ```PHP
-namespace My\Repositories;
+namespace My\Services;
 
 use Trm42\CacheDecorator\CacheDecorator;
 
-class CachedUserRepository extends CacheDecorator {
+class CachedReportingService extends CacheDecorator {
 
-	protected $ttl = 300; // cache ttl in seconds (or a DateInterval / DateTimeInterface)
-	protected $prefix_key = 'users';
-	protected $excludes = ['all']; // these methods are not cached
-
-	public function repository()
-	{
-		return UserRepository::class;
-	}
-
+    protected $ttl = 300; // cache ttl in seconds (or a DateInterval / DateTimeInterface)
+    protected $prefix_key = 'reports';
+    protected $excludes = ['recompute']; // methods listed here are never cached
 }
-
 ```
 
-Aand you're set! The Cache Decorator caches every method call not in the $excludes array. 
+…and use it like this:
 
-*Please note this the current version doesn't support objects as part of the method call. It will be added to v1.0.0.*
+```PHP
+$cached = new CachedReportingService(new ReportingService);
 
-If you need something really special handling for some methods you can always override them in the Cached Repository class like this (simple example):
+$cached->dailyTotals('2026-05-12'); // cache miss → calls ReportingService::dailyTotals
+$cached->dailyTotals('2026-05-12'); // cache hit  → returns the cached value
+```
+
+The decorator forwards any method not listed in `$excludes` to the underlying object via `__call()` and caches the result. *The current version doesn't support objects as method arguments — coming in v1.0.0.*
+
+### Optional: have the decorator instantiate the inner class for you
+
+If you don't want to wire the inner instance yourself, override `decoratedClass()` to return its FQCN and you can construct the decorator with no arguments:
+
+```PHP
+class CachedReportingService extends CacheDecorator {
+    protected $prefix_key = 'reports';
+
+    protected function decoratedClass(): ?string
+    {
+        return ReportingService::class;
+    }
+}
+
+$cached = new CachedReportingService;
+```
+
+### Custom caching logic for a single method
+
+If a particular method needs hand-tuned caching, override it in the subclass and use the protected helpers:
 
 ```PHP
 public function findByX($x)
 {
+    $key = $this->generateCacheKey(__FUNCTION__, compact('x'));
 
-	$key = $this->generateCacheKey(__FUNCTION__, compact($x));
+    $res = $this->getCache($key);
 
-	$res = $this->getCache($key);
+    if (!$res) {
+        $res = $this->decorated->findX($x);
 
-	if (!$res) {
-		$results = $this->repository->findX($x);
-		
-		$this->putCache($key, $results);
-	}
+        $this->putCache($key, $res);
+    }
 
-	return $res;
-
+    return $res;
 }
 ```
 
-If you happen to use a cache driver that enables you to use cache tags, you can clear the cache automatically when the data changes:
+### Cache tags
+
+If your cache driver supports tags, declare which methods invalidate the tag bucket:
+
 ```PHP
-// Additional properties to add to the earlier example
-// with class decoration
-protected $tag_cleaners = ['create'];
-protected $tags = ['users'];
+protected $tag_cleaners = ['recompute'];
+protected $tags = ['reports'];
 ```
 
-Aaand you're set! 
+## Using with repositories
+
+For repository-flavored use cases the package ships `RepositoryCacheDecorator`, which preserves the original repository API: subclasses implement `repository()` returning the wrapped repository class name, and the instance is exposed as `$this->repository`.
+
+```PHP
+namespace My\Repositories;
+
+use Trm42\CacheDecorator\RepositoryCacheDecorator;
+
+class CachedUserRepository extends RepositoryCacheDecorator {
+
+    protected $ttl = 300;
+    protected $prefix_key = 'users';
+    protected $excludes = ['allWithoutCache'];
+    protected $tag_cleaners = ['create'];
+    protected $tags = ['users'];
+
+    public function repository()
+    {
+        return UserRepository::class;
+    }
+
+    // optional per-method override
+    public function findByX($x)
+    {
+        $key = $this->generateCacheKey(__FUNCTION__, compact('x'));
+
+        $res = $this->getCache($key);
+
+        if (!$res) {
+            $res = $this->repository->findX($x);
+            $this->putCache($key, $res);
+        }
+
+        return $res;
+    }
+}
+```
+
+`RepositoryCacheDecorator` reads its config from the `repository_cache.*` namespace, while the generic `CacheDecorator` reads from `cache_decorator.*`. Both work side-by-side.
 
 ## Install
 
@@ -109,12 +155,41 @@ Install with composer:
 composer require trm42/cache-decorator
 ```
 
-Copy the default configuration:
+Publish whichever config you need (or both):
 ```bash
-cp vendor/trm42/cache-decorator/config/repository_cache.php ./config/
+# Generic CacheDecorator config
+php artisan vendor:publish --tag=cache-decorator-config
+
+# Repository-flavored config
+php artisan vendor:publish --tag=repository-cache-config
 ```
 
-## Upgrading from Laravel 5.x versions
+Environment variables:
+
+| Config                          | Env var                    | Default |
+| ------------------------------- | -------------------------- | ------- |
+| `cache_decorator.enabled`       | `CACHE_DECORATOR_ENABLED`  | `true`  |
+| `cache_decorator.ttl`           | `CACHE_DECORATOR_TTL`      | `300`   |
+| `cache_decorator.use_tags`      | `CACHE_DECORATOR_TAGS`     | `true`  |
+| `repository_cache.enabled`      | `REPOSITORY_CACHE`         | `true`  |
+| `repository_cache.ttl`          | `REPOSITORY_CACHE_TTL`     | `300`   |
+| `repository_cache.use_tags`     | `REPOSITORY_CACHE_TAGS`    | `true`  |
+
+## Upgrading
+
+### From the repository-only version
+
+The base class is now generic. If your existing cached repository classes `extends CacheDecorator`, switch them to `extends RepositoryCacheDecorator` — your `repository()` method, the `$this->repository` property in custom overrides, and the `repository_cache.*` config all keep working.
+
+```diff
+-use Trm42\CacheDecorator\CacheDecorator;
++use Trm42\CacheDecorator\RepositoryCacheDecorator;
+
+-class CachedUserRepository extends CacheDecorator {
++class CachedUserRepository extends RepositoryCacheDecorator {
+```
+
+### From Laravel 5.x versions
 
 This release targets Laravel 12 and 13 on PHP 8.2+. A few breaking changes:
 

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "trm42/cache-decorator",
-    "description": "Magical (as in saves manual work quite a lot) Cache Decorator for Laravel. Designed for usage with repositories but easily usable for other uses. If there's enough interest, can be made framework agnostic.",
+    "description": "Magical (as in saves manual work quite a lot) Cache Decorator for Laravel. Generic decorator that transparently caches method calls on any wrapped object, with a RepositoryCacheDecorator subclass for the original repository-flavored use case.",
     "type": "library",
-    "keywords": ["laravel", "cache", "decorator", "repository", "laravel 12", "laravel 13"],
+    "keywords": ["laravel", "cache", "decorator", "cache-decorator", "repository", "service", "laravel 12", "laravel 13"],
     "require": {
         "php": "^8.2",
         "illuminate/cache": "^12.0 || ^13.0",

--- a/config/cache_decorator.php
+++ b/config/cache_decorator.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'enabled' => env('CACHE_DECORATOR_ENABLED', true),
+    // TTL in seconds (Laravel 5.8+ semantic). Default: 5 minutes.
+    'ttl' => env('CACHE_DECORATOR_TTL', 300),
+    'use_tags' => env('CACHE_DECORATOR_TAGS', true),
+
+];

--- a/src/CacheDecorator.php
+++ b/src/CacheDecorator.php
@@ -12,48 +12,48 @@ use Illuminate\Support\Facades\Log;
 use BadMethodCallException;
 use DateInterval;
 use DateTimeInterface;
+use LogicException;
 
 /**
- * Magical Cache Decorator class for Repositories. Meant to be sub classed.
+ * Magical Cache Decorator class. Meant to be sub classed.
  *
- * Base Cache Decorator class for repositories. Sub class this (e.g.
- * class CachedUserRepository extends CacheDecorator and input repository
- * specific settings as class properties and create the 'repository()' method.
- * That method should return only the name of the repository class.
+ * Base Cache Decorator class for transparently caching method calls on any
+ * decorated object (services, repositories, API clients, query objects, etc.).
+ * Sub class this (e.g. class CachedReportingService extends CacheDecorator) and
+ * either pass an instance to the constructor or override decoratedClass() to
+ * return the FQCN to default-instantiate.
  *
- * This class isn't interested in the implementation of the models or the repository.
+ * If you need to create method specific caching logic, you can create a new
+ * method on the sub-classed decorator class. This class automatically forwards
+ * uncached method calls to the decorated object (@see __call()) and caches the
+ * result, removing the need to write boilerplate caching code for every method.
  *
- * If you need to create repository method specific caching logic, you can create
- * new method to the sub-classed cache class (Like CachedUserRepository->all()) .
- * This class automatically calls repository methods and caches them (@see __call())
- * thus lessening the need to write boilerplate caching code for every repository
- * method.
- *
- * For caching relationships, please make sure you're using eager loading (e.g.
- * Eloquent's with() or load() -methods)
+ * For caching relationships in ORM scenarios, please make sure you're using
+ * eager loading (e.g. Eloquent's with() or load() -methods).
  *
  * @author  Matias Mäki <matias.maki@gmail.com>
  * @package Trm42\CacheDecorator;
  *
- * @property   object                                            $repository     Repository object
+ * @property   object                                            $decorated      Decorated object whose method calls are cached
  * @property   int|false|DateInterval|DateTimeInterface|null    $ttl            Cache entry TTL in seconds (or DateInterval / DateTimeInterface). false to skip cache.
  * @property   bool                                              $enabled        To skip or to not to skip the caching, useful for dev envs
- * @property   string                                            $prefix_key     Beginning of the cache key (like 'users' for user repo)
- * @property   array                                             $excludes       List of repository that must not be cached (like inserts, setters, etc)
+ * @property   string                                            $prefix_key     Beginning of the cache key (like 'users' for a user-related decorator)
+ * @property   array                                             $excludes       List of methods that must not be cached (like inserts, setters, etc)
  * @property   array|false                                       $tag_cleaners   If using Cache implementation that supports tags, list of methods that clears the cache tags (like inserts, updates)
- * @property   array|false                                       $tags           List of caching tags associated with the repository cache (like users, photos)
+ * @property   array|false                                       $tags           List of caching tags associated with the decorator cache (like users, photos)
  * @property   bool                                              $debug          Defines whether we're logging, how the cache works, listens app.debug as default
+ * @property   string                                            $config_key     Config namespace this decorator reads from (default 'cache_decorator')
  *
  *
  * @todo    change method check case insensitive if it's possible everywhere
  * @todo    Add some kind of timer functionality to monitor result and cache speed
  * @todo    How to handle empty returns (maybe config whether to cache empty or not and the placeholder)
  * @todo    How to live without Laravel dependencies?
- * @todo    What if the repository parameters are objects? O___O
+ * @todo    What if the decorated method parameters are objects? O___O
  */
 abstract class CacheDecorator {
 
-    protected $repository;
+    protected $decorated;
 
     protected $ttl;
 
@@ -69,24 +69,30 @@ abstract class CacheDecorator {
 
     protected $debug = false;
 
-    /**
-     * You need to implement this per sub-class.
-     *
-     * @return  string  Name of the repository class. Used for instiating the repository
-     *
-     */
-    abstract public function repository();
+    protected string $config_key = 'cache_decorator';
 
     /**
-     * Constructor, accepts the repository object as parameters
+     * Override to return the FQCN of the class to default-instantiate when no
+     * instance is passed to the constructor. Return null (the default) to
+     * require an instance via the constructor.
      *
-     * @param   object|false  $repository     Repository object if you need to define it
+     * @return  string|null  FQCN of the decorated class, or null
+     */
+    protected function decoratedClass(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * Constructor, accepts the decorated object as parameter
+     *
+     * @param   object|false  $decorated     Decorated object if you need to define it
      *
      */
-    public function __construct($repository = false)
+    public function __construct($decorated = false)
     {
         $this->initExcludes();
-        $this->initRepository($repository);
+        $this->initDecorated($decorated);
         $this->getConfig();
     }
 
@@ -96,7 +102,7 @@ abstract class CacheDecorator {
      */
     protected function initExcludes(): void
     {
-        $defaults = [   'repository', 'setTtl', 'setEnabled', 'getConfig', 'initRepository',
+        $defaults = [   'decoratedClass', 'setTtl', 'setEnabled', 'getConfig', 'initDecorated',
                         'doesMethodClearTag', 'clearCacheTag', 'getCache', 'putCache',
                         'isMethodCacheable', 'generateCacheKey', 'log',                      ];
 
@@ -125,15 +131,15 @@ abstract class CacheDecorator {
 
 
     /**
-     * Reads the config values from repository_cache.* values. Note debug listens app.debug.
+     * Reads the config values from {config_key}.* values. Note debug listens app.debug.
      *
      */
     protected function getConfig(): void
     {
-        $this->ttl = Config::get('repository_cache.ttl');
-        $this->enabled = Config::get('repository_cache.enabled');
+        $this->ttl = Config::get("{$this->config_key}.ttl");
+        $this->enabled = Config::get("{$this->config_key}.enabled");
 
-        if (!Config::get('repository_cache.use_tags')) {
+        if (!Config::get("{$this->config_key}.use_tags")) {
             $this->tags = false;
             $this->tag_cleaners = false;
         }
@@ -143,32 +149,40 @@ abstract class CacheDecorator {
     }
 
     /**
-     * Handles the initiating or setting of the repository
+     * Handles the initiating or setting of the decorated object
      *
-     * @param   object|false    $repository
+     * @param   object|false    $decorated
      */
-    public function initRepository($repository): void
+    public function initDecorated($decorated): void
     {
-        if (!$repository) {
-            $class = $this->repository();
-            $repository = new $class;
+        if (!$decorated) {
+            $class = $this->decoratedClass();
+
+            if (!$class) {
+                throw new LogicException(
+                    'No decorated object provided and decoratedClass() returned null. '
+                    . 'Either pass an instance to the constructor or override decoratedClass().'
+                );
+            }
+
+            $decorated = new $class;
         }
 
-        $this->repository = $repository;
+        $this->decorated = $decorated;
     }
 
     /**
      * This is where the magic happens :)
      *
      * If the method is not declared in the cache decorator class (e.g.
-     * CachedUserRepository), then this checks if it's declared in the actual repository
-     * class AND checks if the method call result can be cached and if there's need for
-     * cache tag clean or not
+     * CachedReportingService), then this checks if it's declared in the
+     * decorated object AND checks if the method call result can be cached and
+     * if there's need for cache tag clean or not.
      *
      * @param   string  $method     Name of the method
      * @param   array   $arguments  Arguments for the method and for generating cache key
      *
-     * @return  mixed   Repository results
+     * @return  mixed   Decorated object's results
      */
     public function __call($method, $arguments)
     {
@@ -182,7 +196,7 @@ abstract class CacheDecorator {
 
             if (!$res) {
 
-                $this->log('Cache empty, asking from Repository');
+                $this->log('Cache empty, asking from decorated object');
 
                 $res = $this->callMethod($method, $arguments);
 
@@ -262,10 +276,10 @@ abstract class CacheDecorator {
     }
 
     /**
-     * Save repository results to cache
+     * Save decorated object's results to cache
      *
      * @param string    $key   Cache key
-     * @param mixed     $res   Repository results
+     * @param mixed     $res   Decorated method results
      *
      * @return bool     Did the save succeed?
      *
@@ -288,21 +302,21 @@ abstract class CacheDecorator {
     }
 
     /**
-     * Method for making calls to the repository
+     * Method for making calls to the decorated object
      *
      * @param   string  $method     Name of the method
      * @param   array   $arguments  Arguments for the method
-     * @return  mixed   What ever the repository method returns
-     * @throws  BadMethodCallException  If the method doesn't exist in the repository
+     * @return  mixed   What ever the decorated method returns
+     * @throws  BadMethodCallException  If the method doesn't exist on the decorated object
      */
     protected function callMethod(string $method, array $arguments)
     {
-        if (method_exists($this->repository, $method)) {
-            $this->log('Calling method from the repository');
-            return call_user_func_array([$this->repository, $method], $arguments);
+        if (method_exists($this->decorated, $method)) {
+            $this->log('Calling method from the decorated object');
+            return call_user_func_array([$this->decorated, $method], $arguments);
         }
 
-        throw new BadMethodCallException("Method '{$method}' does not exist in the repository");
+        throw new BadMethodCallException("Method '{$method}' does not exist in the decorated object");
     }
 
     /**

--- a/src/RepositoryCacheDecorator.php
+++ b/src/RepositoryCacheDecorator.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Trm42\CacheDecorator;
+
+/**
+ * Repository-flavored Cache Decorator.
+ *
+ * Specializes CacheDecorator for the repository use case: subclasses implement
+ * repository() returning the wrapped repository class name, the decorated
+ * instance is also exposed as $this->repository for use in custom method
+ * overrides, and config is read from the 'repository_cache.*' namespace.
+ *
+ * Example:
+ *
+ *     class CachedUserRepository extends RepositoryCacheDecorator {
+ *         protected $prefix_key = 'users';
+ *         protected $excludes = ['allWithoutCache'];
+ *
+ *         public function repository()
+ *         {
+ *             return UserRepository::class;
+ *         }
+ *     }
+ */
+abstract class RepositoryCacheDecorator extends CacheDecorator {
+
+    protected string $config_key = 'repository_cache';
+
+    protected $repository;
+
+    /**
+     * Implement this per sub-class.
+     *
+     * @return  string  Name of the repository class. Used for instantiating the repository
+     */
+    abstract public function repository();
+
+    /**
+     * Bridges the repository() abstract method into the generic
+     * decoratedClass() hook used by the base constructor.
+     */
+    protected function decoratedClass(): ?string
+    {
+        return $this->repository();
+    }
+
+    /**
+     * Exclude repository() (subclass-defined public method) from __call interception.
+     */
+    protected function initExcludes(): void
+    {
+        parent::initExcludes();
+
+        $this->excludes = array_merge($this->excludes, ['repository', 'initRepository']);
+    }
+
+    /**
+     * Initialize the wrapped repository, mirroring the instance into
+     * $this->repository so custom method overrides can keep using the
+     * familiar $this->repository->someMethod() idiom.
+     *
+     * @param   object|false    $repository
+     */
+    public function initDecorated($repository): void
+    {
+        parent::initDecorated($repository);
+
+        $this->repository = $this->decorated;
+    }
+
+    /**
+     * Backwards-compatible alias for initDecorated().
+     *
+     * @param   object|false    $repository
+     */
+    public function initRepository($repository): void
+    {
+        $this->initDecorated($repository);
+    }
+
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -12,6 +12,10 @@ class ServiceProvider extends BaseServiceProvider {
 	public function boot(): void
 	{
 	    $this->publishes([
+	        __DIR__.'/../config/cache_decorator.php' => config_path('cache_decorator.php'),
+	    ], 'cache-decorator-config');
+
+	    $this->publishes([
 	        __DIR__.'/../config/repository_cache.php' => config_path('repository_cache.php'),
 	    ], 'repository-cache-config');
 	}

--- a/src/tests/CachedStubServiceTest.php
+++ b/src/tests/CachedStubServiceTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Trm42\CacheDecorator\Tests;
+
+use Illuminate\Support\Facades\Cache;
+use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Trm42\CacheDecorator\ServiceProvider;
+use Trm42\CacheDecorator\Tests\Stubs\CachedAutoStubService;
+use Trm42\CacheDecorator\Tests\Stubs\CachedStubService;
+use Trm42\CacheDecorator\Tests\Stubs\StubService;
+
+/**
+ * Exercises the generic CacheDecorator path with a non-repository service stub.
+ */
+class CachedStubServiceTest extends TestCase
+{
+
+    protected $service;
+
+    protected $inner;
+
+    protected function getPackageProviders($app)
+    {
+        return [ServiceProvider::class];
+    }
+
+    protected function defineEnvironment($app)
+    {
+        $app['config']->set('cache.default', 'array');
+        $app['config']->set('cache_decorator.enabled', true);
+        $app['config']->set('cache_decorator.ttl', 300);
+        $app['config']->set('cache_decorator.use_tags', false);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::flush();
+
+        $this->inner = new StubService;
+        $this->service = new CachedStubService($this->inner);
+        $this->service->setEnabled(true);
+        $this->service->setTtl(300);
+    }
+
+    #[Test]
+    public function testCacheHitOnSecondCall()
+    {
+        $first = $this->service->compute(21);
+        $second = $this->service->compute(21);
+
+        $this->assertEquals(42, $first);
+        $this->assertEquals(42, $second);
+        $this->assertEquals(1, $this->inner->callCount, 'Second call should hit cache, not underlying service');
+    }
+
+    #[Test]
+    public function testCacheKeysVaryByArgument()
+    {
+        $this->service->compute(5);
+        $this->service->compute(7);
+
+        $this->assertEquals(2, $this->inner->callCount);
+    }
+
+    #[Test]
+    public function testExcludedMethodBypassesCache()
+    {
+        $this->service->mutate();
+        $this->service->mutate();
+        $this->service->mutate();
+
+        $this->assertEquals(3, $this->inner->callCount);
+    }
+
+    #[Test]
+    public function testMissingMethodThrows()
+    {
+        $this->expectException(\BadMethodCallException::class);
+
+        $this->service->doesNotExist();
+    }
+
+    #[Test]
+    public function testSetTTLToFalseBypassesCache()
+    {
+        Cache::shouldReceive('get')->never();
+        Cache::shouldReceive('put')->never();
+
+        $this->service->setTtl(false);
+
+        $this->service->compute(3);
+    }
+
+    #[Test]
+    public function testNoArgConstructionViaDecoratedClass()
+    {
+        $service = new CachedAutoStubService;
+        $service->setTtl(300);
+
+        $result = $service->findThing(7);
+
+        $this->assertEquals(['id' => 7, 'name' => 'thing-7'], $result);
+    }
+
+    #[Test]
+    public function testConstructorWithoutInstanceOrDecoratedClassThrows()
+    {
+        $this->expectException(\LogicException::class);
+
+        new CachedStubService;
+    }
+
+    #[Test]
+    public function testArrayArgumentCaches()
+    {
+        $this->service->findThing(1);
+        $this->service->findThing(1);
+
+        $this->assertEquals(1, $this->inner->callCount);
+    }
+
+}

--- a/src/tests/stubs/CachedAutoStubService.php
+++ b/src/tests/stubs/CachedAutoStubService.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Trm42\CacheDecorator\Tests\Stubs;
+
+use Trm42\CacheDecorator\CacheDecorator;
+
+/**
+ * Generic CacheDecorator subclass that uses decoratedClass() to default
+ * instantiate StubService, allowing no-arg construction.
+ */
+class CachedAutoStubService extends CacheDecorator {
+
+    protected $prefix_key = 'auto-svc';
+
+    protected function decoratedClass(): ?string
+    {
+        return StubService::class;
+    }
+
+}

--- a/src/tests/stubs/CachedStubRepository.php
+++ b/src/tests/stubs/CachedStubRepository.php
@@ -2,14 +2,14 @@
 
 namespace Trm42\CacheDecorator\Tests\Stubs;
 
-use Trm42\CacheDecorator\CacheDecorator;
+use Trm42\CacheDecorator\RepositoryCacheDecorator;
 
 /**
  * Nothing fancy, just really simple array class to mock repository
  *
  *
  */
-class CachedStubRepository extends CacheDecorator {
+class CachedStubRepository extends RepositoryCacheDecorator {
 
 	protected $excludes = ['allWithoutCache', 'insert'];
 

--- a/src/tests/stubs/CachedStubService.php
+++ b/src/tests/stubs/CachedStubService.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Trm42\CacheDecorator\Tests\Stubs;
+
+use Trm42\CacheDecorator\CacheDecorator;
+
+/**
+ * Generic CacheDecorator subclass that wraps a constructor-injected StubService
+ * instance. Exercises the no-decoratedClass() path.
+ */
+class CachedStubService extends CacheDecorator {
+
+    protected $prefix_key = 'svc';
+
+    protected $excludes = ['mutate'];
+
+}

--- a/src/tests/stubs/StubService.php
+++ b/src/tests/stubs/StubService.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Trm42\CacheDecorator\Tests\Stubs;
+
+/**
+ * Plain non-repository service to exercise the generic CacheDecorator path.
+ */
+class StubService {
+
+    public int $callCount = 0;
+
+    public function compute(int $x): int
+    {
+        $this->callCount++;
+        return $x * 2;
+    }
+
+    public function findThing(int $id): array
+    {
+        $this->callCount++;
+        return ['id' => $id, 'name' => "thing-{$id}"];
+    }
+
+    public function mutate(): bool
+    {
+        $this->callCount++;
+        return true;
+    }
+
+}


### PR DESCRIPTION
## Summary
- Presents the package as a generic method-caching decorator: `CacheDecorator` now wraps any object via `$this->decorated`, reads config from `cache_decorator.*`, and uses an optional `decoratedClass()` hook instead of an abstract `repository()` method.
- Moves repository-specific semantics into a new `RepositoryCacheDecorator` subclass that preserves the original API (`abstract repository()`, `$this->repository` property mirror, `repository_cache.*` config namespace).
- `ServiceProvider` now publishes both `config/cache_decorator.php` (new, with `CACHE_DECORATOR_*` env vars) and `config/repository_cache.php` (unchanged).
- Adds `StubService` / `CachedStubService` / `CachedAutoStubService` stubs plus `CachedStubServiceTest` (8 tests) covering the generic path: cache hit/miss, excluded methods, missing-method exception, `setTtl(false)` bypass, no-arg construction via `decoratedClass()`, the `LogicException` failure path, and array arguments.
- README rewritten to lead with the generic use case; repository usage moved under a "Using with repositories" section. Upgrade note documents the one-line `extends CacheDecorator` → `extends RepositoryCacheDecorator` change for existing users.
- `composer.json` description / keywords broadened; `CLAUDE.md` architecture and conventions updated.

## Why
Today users meet a class called `CacheDecorator` whose abstract method is `repository()` — friendly only to the repository pattern. Splitting it lets services, API clients, query objects, etc. use the same machinery without semantic mismatch, while keeping the existing repository ergonomics intact for current users.

## Upgrade path
One-line change in consumer code: `extends CacheDecorator` → `extends RepositoryCacheDecorator`. Existing `repository()` methods, `$this->repository` references, and `repository_cache.*` config keep working as-is.

## Test plan
- [x] `composer test` — all 23 tests pass (15 existing + 8 new generic-path tests)
- [ ] In a host Laravel app: `php artisan vendor:publish --tag=cache-decorator-config` writes `config/cache_decorator.php`
- [ ] In a host Laravel app: `php artisan vendor:publish --tag=repository-cache-config` still writes `config/repository_cache.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)