### PR TITLE
Resolve decorated class through the container in initDecorated()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ The package is intentionally small — four production files plus tests.
 - **Config** is read in `getConfig()` from `{$this->config_key}.*` (`ttl`, `enabled`, `use_tags`) plus `app.debug` for the `$debug` flag controlling `Log::debug` output. The base default is `'cache_decorator'`; `RepositoryCacheDecorator` overrides it to `'repository_cache'`.
 - **`src/ServiceProvider.php`** — publishes both config files: `config/cache_decorator.php` under the `cache-decorator-config` tag and `config/repository_cache.php` under the `repository-cache-config` tag; `register()` is empty. The provider is auto-discovered via `extra.laravel.providers` in `composer.json`.
 
-The classes use Laravel facades (`Cache`, `Config`, `Log` from `Illuminate\Support\Facades`), so this package is Laravel-coupled — the TODO in the header notes a future goal to decouple. When testing the no-arg construction path, the decorated class is instantiated via `new $class` inside `initDecorated()` unless an instance is injected through the constructor.
+The classes use Laravel facades (`Cache`, `Config`, `Log` from `Illuminate\Support\Facades`), so this package is Laravel-coupled — the TODO in the header notes a future goal to decouple. When testing the no-arg construction path, the decorated class is resolved through Laravel's service container via `resolve($class)` inside `initDecorated()` unless an instance is injected through the constructor. Because resolution goes through the container, the decorated class may declare auto-wired constructor dependencies and `decoratedClass()` may return a container-bound interface.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ class CachedReportingService extends CacheDecorator {
 $cached = new CachedReportingService;
 ```
 
+The FQCN returned by `decoratedClass()` is resolved through Laravel's service container (via `resolve()`), so the decorated class may declare constructor dependencies (they are auto-wired), and `decoratedClass()` may return an interface that's bound in the container.
+
 ### Custom caching logic for a single method
 
 If a particular method needs hand-tuned caching, override it in the subclass and use the protected helpers:

--- a/src/CacheDecorator.php
+++ b/src/CacheDecorator.php
@@ -93,9 +93,12 @@ abstract class CacheDecorator
     }
 
     /**
-     * Override to return the FQCN of the class to default-instantiate when no
-     * instance is passed to the constructor. Return null (the default) to
-     * require an instance via the constructor.
+     * Override to return the FQCN of the class to resolve when no instance is
+     * passed to the constructor. The FQCN is resolved through Laravel's service
+     * container via resolve(), so the decorated class may declare auto-wired
+     * constructor dependencies, and this may return an interface bound in the
+     * container. Return null (the default) to require an instance via the
+     * constructor.
      *
      * @return class-string<TInner>|null FQCN of the decorated class, or null
      */
@@ -182,7 +185,7 @@ abstract class CacheDecorator
                 );
             }
 
-            $decorated = new $class;
+            $decorated = resolve($class);
         }
 
         $this->decorated = $decorated;

--- a/src/tests/CachedStubServiceTest.php
+++ b/src/tests/CachedStubServiceTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\Test;
 use Trm42\CacheDecorator\ServiceProvider;
 use Trm42\CacheDecorator\Tests\Stubs\CachedAutoStubService;
 use Trm42\CacheDecorator\Tests\Stubs\CachedStubService;
+use Trm42\CacheDecorator\Tests\Stubs\CachedStubServiceWithDependency;
 use Trm42\CacheDecorator\Tests\Stubs\StubService;
 
 /**
@@ -103,6 +104,18 @@ class CachedStubServiceTest extends TestCase
         $result = $service->findThing(7);
 
         $this->assertEquals(['id' => 7, 'name' => 'thing-7'], $result);
+    }
+
+    #[Test]
+    public function test_decorated_class_is_resolved_through_container_with_dependencies()
+    {
+        // StubServiceWithDependency requires a StubCollaborator constructor
+        // argument, so `new $class` would fail. Resolving through the container
+        // auto-wires the dependency.
+        $service = new CachedStubServiceWithDependency;
+        $service->setTtl(300);
+
+        $this->assertEquals('hello from collaborator', $service->delegatedGreeting());
     }
 
     #[Test]

--- a/src/tests/Stubs/CachedStubServiceWithDependency.php
+++ b/src/tests/Stubs/CachedStubServiceWithDependency.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Trm42\CacheDecorator\Tests\Stubs;
+
+use Trm42\CacheDecorator\CacheDecorator;
+
+/**
+ * CacheDecorator subclass whose decoratedClass() returns a service with a
+ * constructor dependency, exercising container-based resolution in
+ * initDecorated().
+ *
+ * @extends CacheDecorator<StubServiceWithDependency>
+ */
+class CachedStubServiceWithDependency extends CacheDecorator
+{
+    protected ?string $prefix_key = 'dep-svc';
+
+    #[\Override]
+    protected function decoratedClass(): ?string
+    {
+        return StubServiceWithDependency::class;
+    }
+}

--- a/src/tests/Stubs/StubCollaborator.php
+++ b/src/tests/Stubs/StubCollaborator.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Trm42\CacheDecorator\Tests\Stubs;
+
+/**
+ * A simple collaborator that gets injected into StubServiceWithDependency to
+ * prove constructor dependencies are auto-wired by the container.
+ */
+class StubCollaborator
+{
+    public function greeting(): string
+    {
+        return 'hello from collaborator';
+    }
+}

--- a/src/tests/Stubs/StubServiceWithDependency.php
+++ b/src/tests/Stubs/StubServiceWithDependency.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Trm42\CacheDecorator\Tests\Stubs;
+
+/**
+ * Service with a constructor dependency, used to prove that decoratedClass()
+ * resolution goes through Laravel's container and auto-wires the dependency.
+ */
+class StubServiceWithDependency
+{
+    public function __construct(protected StubCollaborator $collaborator) {}
+
+    public function delegatedGreeting(): string
+    {
+        return $this->collaborator->greeting();
+    }
+}


### PR DESCRIPTION
## What

`CacheDecorator::initDecorated()` now resolves the decorated class through Laravel's service container (`resolve($class)`) instead of `new $class` when no instance is passed to the constructor.

## Why

The package is already Laravel-coupled (it uses the `Cache`, `Config`, and `Log` facades), and direct instantiation only worked for classes with a zero-argument constructor — it ignored the container entirely. Resolving through the container is a strictly-more-capable, low-risk upgrade:

- Decorated classes may now declare **auto-wired constructor dependencies**.
- `decoratedClass()` may return an **interface bound in the container**.
- Existing no-dependency stubs resolve identically, so the no-arg path is behaviorally unchanged.

## Changes

- **`src/CacheDecorator.php`** — `$decorated = new $class;` → `$decorated = resolve($class);`. The `LogicException` null-class guard is unchanged (it fires before the container is touched). Updated the `decoratedClass()` PHPDoc.
- **`README.md`** / **`CLAUDE.md`** — documented container-based resolution per the README-sync convention.
- **Tests** — added `StubCollaborator`, `StubServiceWithDependency` (requires the collaborator in its constructor), and `CachedStubServiceWithDependency`, plus `test_decorated_class_is_resolved_through_container_with_dependencies`. The service has a required constructor argument, so the old `new $class` path would have thrown `ArgumentCountError` — the test only passes because resolution auto-wires the dependency.

## Verification

`composer test` — 29 tests, 43 assertions, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)